### PR TITLE
Added better handling for v5.0.0+ and newer Androids.

### DIFF
--- a/config-track.yml
+++ b/config-track.yml
@@ -29,7 +29,7 @@ music_format:
   subtitle: null
   comments: null
   artist: "{song.artist}"
-  album_artist: "Rayark"
+  album_artist: "Rayark - Ripped by Schryzon"
   album: "Cytus II Original Soundtrack"
   year: null
   number: "{song.number}"

--- a/models/SongChart.py
+++ b/models/SongChart.py
@@ -3,7 +3,8 @@ from typing import Optional
 
 class SongChartDifficulty:
     def __init__(self, data, name):
-        self.level = int(data['Level'])
+        #exceptions = ['α', 'β', 'γ']
+        self.level = data['Level']
         self.has_separate_file = data['MusicID'] != ''
         self.is_unlock_needed: bool = data['NeedUnlock']
         self.music_id = data['MusicID']
@@ -22,9 +23,12 @@ class SongChart:
         self.hard: SongChartDifficulty = None
         self.chaos: SongChartDifficulty = None
         self.glitch: Optional[SongChartDifficulty] = None
+        self.crash: Optional[SongChartDifficulty] = None
+        self.drop: Optional[SongChartDifficulty] = None
+        self.dream: Optional[SongChartDifficulty] = None
 
         self.difficulties = list(map(str.lower, data.keys()))
-        self.difficulties.sort(key=['easy', 'hard', 'chaos', 'glitch'].index)
+        self.difficulties.sort(key=['easy', 'hard', 'chaos', 'glitch', 'crash', 'drop', 'dream'].index)
         for difficulty, data in data.items():
             setattr(self, difficulty.lower(), SongChartDifficulty(data, difficulty))
 

--- a/pull-files.py
+++ b/pull-files.py
@@ -60,7 +60,7 @@ def pull_files(tmp):
     asset_bundles = None
 
     for package in adb('shell', 'pm', 'list', 'packages', '-f'):
-        if package.startswith('package:/data/app/com.rayark.cytus2'):
+        if 'com.rayark.cytus2' in package: # Sometimes doesn't work with .startswith()
             apk = package[8:-18]
             print('Found apk at', apk)
             break


### PR DESCRIPTION
Although being an albeit old project, I decided to hop on and introduced tiny bits of fixes:

- Uses `in` for `.apk` checks
- Checks for `.ogg` instead of `.wav` (because it doesn't work with mine on v5.2.0
- Difficulties are kept on strings because of plus (`+`) difficulties and `α`, `β`, `γ` new difficulty variants
- Some `try` and `except`(s) to ensure successful conversion (not fully tested)

Managed to gather **432** audios and converted them into `.flac`-extensioned files

It's a miracle how this still somewhat works... but you *do* need `AssetRipper` for the `.ab` files!

Thanks for the insightful project, and see ya!

![image](https://github.com/user-attachments/assets/93b8b14b-d3ed-416e-a422-93ad33a9cb40)
